### PR TITLE
Fix payback scenario handling

### DIFF
--- a/business/roi_calculator.py
+++ b/business/roi_calculator.py
@@ -227,6 +227,7 @@ class ROICalculator:
             if monthly_benefits <= 0:
                 return {
                     "simple_payback": float('inf'),
+                    "growth_adjusted_payback": float('inf'),
                     "discounted_payback": float('inf'),
                     "break_even_month": float('inf')
                 }

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -157,8 +157,27 @@ class TestInvestmentCaseCalculation:
             primary_goal="Cost Reduction",
             risk_tolerance="Medium"
         )
-        
+
         assert expected_payback(case.payback_months)
+
+    def test_payback_scenarios_zero_benefits(self):
+        """Ensure payback scenario keys exist even with zero benefits"""
+        from business.roi_calculator import roi_calculator
+
+        scenarios = roi_calculator.calculate_payback_scenarios(
+            investment=100000,
+            monthly_benefits=0,
+            growth_rate=0.01,
+            discount_rate=0.05,
+        )
+
+        assert set(scenarios.keys()) == {
+            "simple_payback",
+            "growth_adjusted_payback",
+            "discounted_payback",
+            "break_even_month",
+        }
+        assert all(val == float("inf") for val in scenarios.values())
         
     def test_roi_consistency_across_goals(self):
         """Test ROI consistency across different goals"""


### PR DESCRIPTION
## Summary
- ensure `calculate_payback_scenarios` always returns `growth_adjusted_payback`
- add unit test for zero-benefit payback scenario

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68633cbed08c83338283475443579edc